### PR TITLE
Add config support for generating tower

### DIFF
--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterendisland/module/ConfigModule.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterendisland/module/ConfigModule.java
@@ -3,4 +3,5 @@ package com.yungnickyoung.minecraft.betterendisland.module;
 public class ConfigModule {
     public boolean resummonedDragonDropsEgg = false;
     public boolean useVanillaSpawnPlatform = false;
+    public boolean regenerateTowerOnDragonDeath = false;
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterendisland/module/ConfigModule.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterendisland/module/ConfigModule.java
@@ -3,5 +3,5 @@ package com.yungnickyoung.minecraft.betterendisland.module;
 public class ConfigModule {
     public boolean resummonedDragonDropsEgg = false;
     public boolean useVanillaSpawnPlatform = false;
-    public boolean regenerateTowerOnDragonDeath = false;
+    public boolean regenerateTowerOnDragonDeath = true;
 }

--- a/Fabric/src/main/java/com/yungnickyoung/minecraft/betterendisland/config/ConfigGeneralFabric.java
+++ b/Fabric/src/main/java/com/yungnickyoung/minecraft/betterendisland/config/ConfigGeneralFabric.java
@@ -10,5 +10,5 @@ public class ConfigGeneralFabric {
     public boolean useVanillaSpawnPlatform = false;
 
     @ConfigEntry.Gui.Tooltip
-    public boolean regenerateTowerOnDragonDeath = false;
+    public boolean regenerateTowerOnDragonDeath = true;
 }

--- a/Fabric/src/main/java/com/yungnickyoung/minecraft/betterendisland/config/ConfigGeneralFabric.java
+++ b/Fabric/src/main/java/com/yungnickyoung/minecraft/betterendisland/config/ConfigGeneralFabric.java
@@ -8,4 +8,7 @@ public class ConfigGeneralFabric {
 
     @ConfigEntry.Gui.Tooltip
     public boolean useVanillaSpawnPlatform = false;
+
+    @ConfigEntry.Gui.Tooltip
+    public boolean regenerateTowerOnDragonDeath = false;
 }

--- a/Fabric/src/main/java/com/yungnickyoung/minecraft/betterendisland/module/ConfigModuleFabric.java
+++ b/Fabric/src/main/java/com/yungnickyoung/minecraft/betterendisland/module/ConfigModuleFabric.java
@@ -23,5 +23,6 @@ public class ConfigModuleFabric {
     private static void bakeConfig(BEIConfigFabric configFabric) {
         BetterEndIslandCommon.CONFIG.resummonedDragonDropsEgg = configFabric.general.resummonedDragonDropsEgg;
         BetterEndIslandCommon.CONFIG.useVanillaSpawnPlatform = configFabric.general.useVanillaSpawnPlatform;
+        BetterEndIslandCommon.CONFIG.regenerateTowerOnDragonDeath = configFabric.general.regenerateTowerOnDragonDeath;
     }
 }

--- a/Forge/src/main/java/com/yungnickyoung/minecraft/betterendisland/config/BEIConfigForge.java
+++ b/Forge/src/main/java/com/yungnickyoung/minecraft/betterendisland/config/BEIConfigForge.java
@@ -8,6 +8,7 @@ public class BEIConfigForge {
 
     public static final ForgeConfigSpec.ConfigValue<Boolean> resummonedDragonDropsEgg;
     public static final ForgeConfigSpec.ConfigValue<Boolean> useVanillaSpawnPlatform;
+    public static final ForgeConfigSpec.ConfigValue<Boolean> regenerateTowerOnDragonDeath;
 
     static {
         BUILDER.push("YUNG's Better End Island");
@@ -23,6 +24,12 @@ public class BEIConfigForge {
                         " Whether the vanilla obsidian platform should spawn in the End instead of the revamped platform.\n" +
                         " Default: false")
                 .define("Spawn Vanilla Obsidian Platform", false);
+
+        regenerateTowerOnDragonDeath = BUILDER
+                .comment(
+                        " Whether the tower building surrounding the end podium should be regenerated on subsequent dragon kills. \n" +
+                        " Default: false")
+                .define("Regenerate End Podium Tower", false);
 
         BUILDER.pop();
         SPEC = BUILDER.build();

--- a/Forge/src/main/java/com/yungnickyoung/minecraft/betterendisland/config/BEIConfigForge.java
+++ b/Forge/src/main/java/com/yungnickyoung/minecraft/betterendisland/config/BEIConfigForge.java
@@ -29,7 +29,7 @@ public class BEIConfigForge {
                 .comment(
                         " Whether the tower building surrounding the end podium should be regenerated on subsequent dragon kills. \n" +
                         " Default: false")
-                .define("Regenerate End Podium Tower", false);
+                .define("Regenerate End Podium Tower", true);
 
         BUILDER.pop();
         SPEC = BUILDER.build();

--- a/Forge/src/main/java/com/yungnickyoung/minecraft/betterendisland/module/ConfigModuleForge.java
+++ b/Forge/src/main/java/com/yungnickyoung/minecraft/betterendisland/module/ConfigModuleForge.java
@@ -29,5 +29,6 @@ public class ConfigModuleForge {
     private static void bakeConfig() {
         BetterEndIslandCommon.CONFIG.resummonedDragonDropsEgg = BEIConfigForge.resummonedDragonDropsEgg.get();
         BetterEndIslandCommon.CONFIG.useVanillaSpawnPlatform = BEIConfigForge.useVanillaSpawnPlatform.get();
+        BetterEndIslandCommon.CONFIG.regenerateTowerOnDragonDeath = BEIConfigForge.regenerateTowerOnDragonDeath.get();
     }
 }


### PR DESCRIPTION
# Overview
The purpose of this PR is to address issue #18. A config option is added that will allow a user to determine if the tower over the end podium is generated on subsequent dragon kills.

# Changes
A config option labeled `regenerateTowerOnDragonDeath` was added to determine if the tower structure placement should take place after a dragon kill. This config option was added for both Forge and Fabric, as well as within the common `ConfigModule.java`

Within `EndDragonFightMixin.java`, the method signature for `betterendisland$spawnPortal` was updated to include a third boolean parameter. This value determines if the tower placement takes place.

There are three instances where this value is passed in as true, regardless of the configuration value:
- On the scan for the initial state and the exit portal has not been generated.
- On a respawn, but the exit portal has not been generated.
- On the initial spawn of the dragon.

The main changes take place within the `betterendisland$spawnPortal` method. Namely the logic follows the flow of:
- If the dragon has not been killed previously, regardless of config option, place the tower as expected.
  - Placement of the tower in this scenario is done because the initial tower placement does not contain the open bottom. Keeping this flow allows the destroyed tower with the open bottom to be present.
- If the dragon has been killed previously, and the config value is false, ensure that the variable for tracking if the portal `isActive` is true. Additionally, utilization of `hasActiveExitPortal` combined with `isActive` will ensure that we're not re-creating the exit portal if it already exists.
- If `isActive` is true and `hasActiveExitPortal` is false we "activate" the exit portal by placing end portal blocks following the [structure construction](https://minecraft.wiki/w/Exit_portal#Construction) of the exit portal, though focused on placing only the end portals. A coordinate array is used to determine where end portals should be placed relative to the portal position block (though three below to ensure they are placed in the exit portal ring).

# Testing
Testing was done using the debug functionality within IntelliJ for both Forge and Fabric. The scenarios tested included ensuring initial tower was placed on first spawn, broken blocks were not replaced on subsequent dragon kills with config value set to false, and experience was consistent as before with config value set to true.